### PR TITLE
feature-obter-categoria-por-id

### DIFF
--- a/Crosscutting/Constantes/ErrorMessages.cs
+++ b/Crosscutting/Constantes/ErrorMessages.cs
@@ -3,4 +3,5 @@
 public static class ErrorMessages
 {
     public static string DtoNulo(string campo) => $"O DTO de {campo} não pode ser nulo.";
+    public static string IdNulo(string campo) => $"O ID de {campo} não pode ser nulo.";
 }

--- a/Crosscutting/Constantes/ErrorMessages.cs
+++ b/Crosscutting/Constantes/ErrorMessages.cs
@@ -4,4 +4,5 @@ public static class ErrorMessages
 {
     public static string DtoNulo(string campo) => $"O DTO de {campo} não pode ser nulo.";
     public static string IdNulo(string campo) => $"O ID de {campo} não pode ser nulo.";
+    public static string NaoExiste(string campo) => $"{campo} não existe.";
 }

--- a/Crosscutting/Dtos/Categoria/CategoriaResponseDto.cs
+++ b/Crosscutting/Dtos/Categoria/CategoriaResponseDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Crosscutting.Dtos.Categoria;
+
+public class CategoriaResponseDto
+{
+    public string Nome { get; set; }
+    public string Descricao { get; set; }
+    public bool Ativo { get; set; }
+}

--- a/Crosscutting/Exceptions/NaoEncontradoException.cs
+++ b/Crosscutting/Exceptions/NaoEncontradoException.cs
@@ -1,0 +1,3 @@
+﻿namespace Crosscutting.Exceptions;
+
+public class NaoEncontradoException(string message) : Exception(message);

--- a/Domain/Interfaces/ICategoriaService.cs
+++ b/Domain/Interfaces/ICategoriaService.cs
@@ -5,4 +5,5 @@ namespace Domain.Interfaces;
 public interface ICategoriaService
 {
     Task<Guid> CriarAsync(CategoriaCreationRequestDto categoriaDto);
+    Task<CategoriaResponseDto> ObterPorIdAsync(Guid id);
 }

--- a/Domain/Mappers/CategoriaMapper.cs
+++ b/Domain/Mappers/CategoriaMapper.cs
@@ -23,4 +23,14 @@ public static class CategoriaMapper
             Ativo = true
         };
     }
+
+    public static CategoriaResponseDto MapToResponseDto(this Categoria categoria)
+    {
+        return new CategoriaResponseDto
+        {
+            Nome = categoria.Nome,
+            Descricao = categoria.Descricao,
+            Ativo = categoria.Ativo,
+        };
+    }
 }

--- a/Domain/Services/CategoriaService.cs
+++ b/Domain/Services/CategoriaService.cs
@@ -4,7 +4,6 @@ using Crosscutting.Exceptions;
 using Domain.Interfaces;
 using Domain.Mappers;
 using Domain.Repositories;
-using FluentValidation;
 
 namespace Domain.Services;
 
@@ -17,5 +16,14 @@ public class CategoriaService(ICategoriaRepository repository) : ICategoriaServi
         
         var categoria = categoriaDto.MapToEntity();
         return await repository.AdicionarESalvarAsync(categoria);
+    }
+
+    public async Task<CategoriaResponseDto> ObterPorIdAsync(Guid id)
+    {
+        if (id == Guid.Empty)
+            throw new RequisicaoInvalidaException(ErrorMessages.IdNulo("categoria"));
+
+        var categoria = await repository.ObterPorIdAsync(id);
+        return categoria.MapToResponseDto();
     }
 }

--- a/Domain/Services/CategoriaService.cs
+++ b/Domain/Services/CategoriaService.cs
@@ -1,4 +1,5 @@
-﻿using Crosscutting.Constantes;
+﻿using System.Globalization;
+using Crosscutting.Constantes;
 using Crosscutting.Dtos.Categoria;
 using Crosscutting.Exceptions;
 using Domain.Interfaces;
@@ -23,7 +24,8 @@ public class CategoriaService(ICategoriaRepository repository) : ICategoriaServi
         if (id == Guid.Empty)
             throw new RequisicaoInvalidaException(ErrorMessages.IdNulo("categoria"));
 
-        var categoria = await repository.ObterPorIdAsync(id);
+        var categoria = await repository.ObterPorIdAsync(id)
+            ?? throw new NaoEncontradoException(ErrorMessages.NaoExiste("Categoria"));
         return categoria.MapToResponseDto();
     }
 }

--- a/Test/Domain/Services/CategoriaServiceTest.cs
+++ b/Test/Domain/Services/CategoriaServiceTest.cs
@@ -61,4 +61,46 @@ public class CategoriaServiceTest
 
     }
     #endregion
+    
+    #region ObterPorId
+
+    [Fact]
+    public async Task ObterPorIdAsync_QuandoIdValido_DeveRetornarCategoria()
+    {
+        var categoria = CategoriaBuilder.Novo().Build();
+
+        _categoriaRepositoryMock.Setup(r =>
+            r.ObterPorIdAsync(It.IsAny<Guid>())).ReturnsAsync(categoria);
+        
+        var result = await _categoriaService.ObterPorIdAsync(categoria.Id);
+        result.Should().NotBeNull();
+        result.Should().BeOfType<CategoriaResponseDto>();
+        result.Should().BeEquivalentTo(categoria.MapToResponseDto());
+    }
+    
+    [Fact]
+    public async Task ObterPorIdAsync_QuandoIdVazio_DeveLancarRequisicaoInvalidaException()
+    {
+        Func<Task> act = async () => await _categoriaService.ObterPorIdAsync(Guid.Empty);
+        
+        await act.Should()
+            .ThrowAsync<RequisicaoInvalidaException>()
+            .WithMessage("O ID de categoria não pode ser nulo.");
+    }
+    
+    [Fact]
+    public async Task ObterPorIdAsync_QuandoErroNoBanco_DeveLancarException()
+    {
+        var categoria = CategoriaBuilder.Novo().Build();
+        
+        _categoriaRepositoryMock.Setup(r => r.ObterPorIdAsync(It.IsAny<Guid>()))
+            .ThrowsAsync(new Exception("Falha no banco."));
+        
+        Func<Task> act = async () => await _categoriaService.ObterPorIdAsync(categoria.Id);
+
+        await act.Should()
+            .ThrowAsync<Exception>()
+            .WithMessage("Falha no banco.");
+    }
+    #endregion
 }

--- a/Test/Domain/Services/CategoriaServiceTest.cs
+++ b/Test/Domain/Services/CategoriaServiceTest.cs
@@ -79,6 +79,21 @@ public class CategoriaServiceTest
     }
     
     [Fact]
+    public async Task ObterPorIdAsync_QuandoIdNaoExiste_DeveRetornarNaoEncontradoException()
+    {
+        var categoria = CategoriaBuilder.Novo().Build();
+        
+        _categoriaRepositoryMock.Setup(r => r.ObterPorIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Categoria)null);
+        
+        Func<Task> act = async () => await _categoriaService.ObterPorIdAsync(categoria.Id);
+        
+        await act.Should()
+            .ThrowAsync<NaoEncontradoException>()
+            .WithMessage("Categoria não existe.");
+    }
+    
+    [Fact]
     public async Task ObterPorIdAsync_QuandoIdVazio_DeveLancarRequisicaoInvalidaException()
     {
         Func<Task> act = async () => await _categoriaService.ObterPorIdAsync(Guid.Empty);


### PR DESCRIPTION
Adiciona e implementa ObterPorIdAsync
Adiciona mensagem de erro para Id nulo e campo não existente
Adiciona testes unitários para ObterPorIdAsync
Adiciona CategoriaResponseDto
Adiciona mapeamento de Categoria para CategoriaResponseDto
Adiciona exceção para casos não encontrados

Card Trello: https://trello.com/b/2OmaOS8N/kanban-api-papelaria